### PR TITLE
Prevent errors on fresh installation

### DIFF
--- a/src/Admin/Extension/PageAdminExtension.php
+++ b/src/Admin/Extension/PageAdminExtension.php
@@ -9,7 +9,6 @@ use Partitech\SonataExtra\Contract\MediaInterface;
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
-// use Sonata\AdminBundle\Form\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
@@ -27,20 +26,24 @@ class PageAdminExtension extends AbstractAdminExtension
     private ImageProvider $providerImage;
     private ParameterBagInterface $parameterBag;
 
+    
+    public function __construct(
+        #[Autowire(service:'\Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')] ParameterBagInterface $parameterBag,
+        #[Autowire(service:'\Doctrine\ORM\EntityManagerInterface')] EntityManagerInterface $entityManager,
+        #[Autowire(service:'\Sonata\MediaBundle\Entity\MediaManager')] MediaManager $mediaManager
+    ) {
+        $this->parameterBag  = $parameterBag;
+        $this->entityManager = $entityManager;
+        $this->mediaManager  = $mediaManager
+    }
+
+    
     #[Required]
     public function autowireDependencies(
-        EntityManagerInterface $entityManager,
-        ParameterBagInterface $parameterBag,
-        MediaManager $mediaManager,
         ImageProvider $providerImage,
         RequestStack $requestStack,
     ): void {
-        $this->entityManager = $entityManager;
-        $this->parameterBag = $parameterBag;
-        $this->mediaManager = $mediaManager;
         $this->providerImage = $providerImage;
-
-
         $request = $requestStack->getCurrentRequest();
         if(!empty($request)){
             $smart_service_conf = $this->parameterBag->get('partitech_sonata_extra.smart_service');

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -42,7 +42,7 @@ class Article
 
 
 
-    #[ORM\Column(type: 'text', nullable: true, options: ['charset' => 'utf8mb4', 'collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(type: 'text', nullable: true, options: ['charset' => 'utf8mb4'])]
     #[Translatable]
     private ?string $content = "";
 
@@ -50,7 +50,7 @@ class Article
     #[Translatable]
     private string $title;
 
-    #[ORM\Column(type: 'text',  nullable: true, options: ['charset' => 'utf8mb4', 'collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(type: 'text',  nullable: true, options: ['charset' => 'utf8mb4'])]
     #[Translatable]
     private ?string $excerpt;
 

--- a/src/EventListener/ConsoleContextListener.php
+++ b/src/EventListener/ConsoleContextListener.php
@@ -30,6 +30,10 @@
             
             if (!$siteUrl) {
                 $site = $this->siteManager->findOneBy(['isDefault'=> true]);
+                // if null we may be in the sonata:page:create-site
+                if(null === $site){
+                    return;
+                }
                 $siteUrl = 'https://'.$site->getHost().$site->getRelativePath();
             }
             


### PR DESCRIPTION
- prevent error on create site command. 
- add autowire in _constructor of PageAdminExtension
- Remove collation in entity.

Collation should be set in doctrine.yaml
doctrine:
    dbal:
        charset: utf8mb4
        default_table_options:
            charset: utf8mb4
            collation: utf8mb4_unicode_ci